### PR TITLE
Update README to reflect limitations of plugin options

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ module.exports = {
         appUrl: "https://app.posthog.com", // optional
         enableInDevelopment: false, // optional
         // other options are passed to posthog-js init as is
+        // NOTE: options will be passed through JSON.stringify(), so functions (such as `sanitize_properties`) are not supported.
       },
     ],
   ],

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ module.exports = {
         appUrl: "https://app.posthog.com", // optional
         enableInDevelopment: false, // optional
         // other options are passed to posthog-js init as is
-        // NOTE: options will be passed through JSON.stringify(), so functions (such as `sanitize_properties`) are not supported.
+        // NOTE: options are passed through JSON.stringify(), so functions (such as `sanitize_properties`) are not supported.
       },
     ],
   ],


### PR DESCRIPTION
I [recently learned](https://github.com/foxglove/docs/pull/221#issuecomment-2043720346) that this plugin does not support `sanitize_properties` and other function-based options. This took a lot of digging to uncover what was going on, so I hope adding this note to the readme will help others avoid getting stuck.

See also: https://github.com/PostHog/posthog.com/pull/8227