### PR TITLE
Update script and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# PostHog plugin for Docusaurus v2
+# PostHog plugin for Docusaurus
 
-Please see the main [PostHog docs](https://posthog.com/docs).
-
-Specifically, the [Docusaurus v2 integration](https://posthog.com/docs/integrations/docusaurus-integration) details.
+Easily track and improve your Docusaurus site with PostHog. See [our docs on this plugin](https://posthog.com/docs/libraries/docusaurus) for more information.
 
 ## Installing the plugin
 
@@ -25,21 +23,17 @@ module.exports = {
     [
       "posthog-docusaurus",
       {
-        apiKey: "YOURAPIKEY",
-        appUrl: "https://app.posthog.com", // optional
+        apiKey: "<ph_project_api_key>",
+        appUrl: "<ph_client_api_host>", // optional, defaults to "https://us.i.posthog.com"
         enableInDevelopment: false, // optional
-        // other options are passed to posthog-js init as is
-        // NOTE: options are passed through JSON.stringify(), so functions (such as `sanitize_properties`) are not supported.
       },
     ],
   ],
 };
 ```
 
+> **Note:**You can pass additional PostHog [config options](/docs/libraries/js#config) to the plugin, but they are passed through `JSON.stringify()`, so functions (such as `sanitize_properties`) are not supported.
+
 ## Using the plugin
 
-That's it! You're ready to go!
-
-## Questions?
-
-### [Join our Slack community.](https://join.slack.com/t/posthogusers/shared_invite/enQtOTY0MzU5NjAwMDY3LTc2MWQ0OTZlNjhkODk3ZDI3NDVjMDE1YjgxY2I4ZjI4MzJhZmVmNjJkN2NmMGJmMzc2N2U3Yjc3ZjI5NGFlZDQ)
+Once running, this autocaptures pageviews, events, and session replay (if enabled) and enables usage of other PostHog features like surveys.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "posthog-docusaurus",
-  "version": "2.0.0",
-  "description": "🦔 PostHog plugin for Docusaurus v2",
+  "version": "2.0.1",
+  "description": "🦔 PostHog plugin for Docusaurus",
   "main": "src/index.js",
   "publishConfig": {
     "access": "public"

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ module.exports = function (context, options) {
 
   const {
     apiKey,
-    appUrl = "https://app.posthog.com",
+    appUrl = "https://us.i.posthog.com",
     enableInDevelopment = false,
     ...rest
   } = options;
@@ -50,7 +50,7 @@ module.exports = function (context, options) {
           {
             tagName: "script",
             innerHTML: `
-              !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+              !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
               posthog.init(${JSON.stringify(apiKey)}, ${JSON.stringify(
               posthogInitOptions
             )})


### PR DESCRIPTION
As part of updating the Docusaurus docs, updating the package to use the updated endpoint by default and a newer version of the JS script. Also updating the README to match the docs. 

Tested locally. Works for Docusauraus 3.
