### PR TITLE
Fix: Check previous location on pageview capture

### DIFF
--- a/src/posthog.js
+++ b/src/posthog.js
@@ -6,8 +6,10 @@ export default (function () {
   }
 
   return {
-    onRouteUpdate() {
-      window.posthog.capture('$pageview');
+    onRouteUpdate({location, previousLocation}) {
+      if (location.pathname != previousLocation?.pathname) {
+        window.posthog.capture('$pageview');
+      }
     },
   };
 })();

--- a/src/posthog.js
+++ b/src/posthog.js
@@ -6,7 +6,7 @@ export default (function () {
   }
 
   return {
-    onRouteUpdate({location, previousLocation}) {
+    onRouteUpdate({ location, previousLocation }) {
       if (location.pathname != previousLocation?.pathname) {
         window.posthog.capture('$pageview');
       }


### PR DESCRIPTION
Because `onRouteUpdate` runs when hash changes (like on anchor links), we were capturing a pageview more than we needed to. By checking if the previous location is different, we prevent this. 